### PR TITLE
Adding support for v5 api

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,13 +6,20 @@ require 'rspec'
 RSpec.configure do |config|
   config.before(:all) do
     require 'fake_web'
-    directory = File.join(File.dirname(__FILE__),'tracker')
+    directory = File.join(File.dirname(__FILE__), 'tracker')
     Dir.chdir(directory) do
+      Dir["**/*.json"].each do |file|
+        response = Net::HTTPOK.new("1.1", "200", "OK")
+        response.instance_variable_set(:@body, File.read(file))
+        response.add_field "Content-type", "application/json"
+        url = "https://www.pivotaltracker.com/services/v5/#{file.sub(/\.json$/, '')}"
+        FakeWeb.register_uri(:get, url, :response => response)
+      end
       Dir["**/*.xml"].each do |file|
-        response = Net::HTTPOK.new("1.1","200","OK")
+        response = Net::HTTPOK.new("1.1", "200", "OK")
         response.instance_variable_set(:@body, File.read(file))
         response.add_field "Content-type", "application/xml"
-        url = "https://www.pivotaltracker.com/services/v3/#{file.sub(/\.xml$/,'')}"
+        url = "https://www.pivotaltracker.com/services/v3/#{file.sub(/\.xml$/, '')}"
         FakeWeb.register_uri(:get, url, :response => response)
       end
     end

--- a/spec/tracker/projects/1.json
+++ b/spec/tracker/projects/1.json
@@ -1,0 +1,32 @@
+{
+  "id": 1,
+  "kind": "project",
+  "name": "Sample Project",
+  "version": 1,
+  "iteration_length": 1,
+  "week_start_day": "Monday",
+  "point_scale": "1,2,3",
+  "point_scale_is_custom": true,
+  "bugs_and_chores_are_estimatable": false,
+  "automatic_planning": true,
+  "enable_tasks": true,
+  "time_zone": {
+    "kind": "time_zone",
+    "olson_name": "America/Los_Angeles",
+    "offset": "-07:00"
+  },
+  "velocity_averaged_over": 3,
+  "number_of_done_iterations_to_show": 12,
+  "has_google_domain": false,
+  "enable_incoming_emails": true,
+  "initial_velocity": 10,
+  "public": false,
+  "atom_enabled": false,
+  "project_type": "shared",
+  "start_time": "2017-02-27T08:00:00Z",
+  "created_at": "2017-02-07T18:30:56Z",
+  "updated_at": "2017-03-13T14:59:44Z",
+  "account_id": 1,
+  "current_iteration_number": 3,
+  "enable_following": true
+}

--- a/spec/tracker/projects/1/stories.json
+++ b/spec/tracker/projects/1/stories.json
@@ -1,0 +1,21 @@
+[
+  {
+    "kind": "story",
+    "id": 1,
+    "created_at": "2017-03-14T17:09:07Z",
+    "updated_at": "2017-03-14T17:12:57Z",
+    "estimate": 1,
+    "story_type": "feature",
+    "name": "TestPickler",
+    "description": "",
+    "current_state": "started",
+    "requested_by_id": 1,
+    "url": "https://www.pivotaltracker.com/story/show/1",
+    "project_id": 1,
+    "owner_ids": [
+      1
+    ],
+    "labels": [],
+    "owned_by_id": 1
+  }
+]

--- a/spec/tracker/projects/1/stories/1.json
+++ b/spec/tracker/projects/1/stories/1.json
@@ -1,0 +1,19 @@
+{
+  "kind": "story",
+  "id": 1,
+  "created_at": "2017-03-14T17:09:07Z",
+  "updated_at": "2017-03-14T17:12:57Z",
+  "estimate": 1,
+  "story_type": "feature",
+  "name": "TestPickler",
+  "description": "",
+  "current_state": "started",
+  "requested_by_id": 1,
+  "url": "https://www.pivotaltracker.com/story/show/1",
+  "project_id": 1,
+  "owner_ids": [
+    1
+  ],
+  "labels": [],
+  "owned_by_id": 1
+}


### PR DESCRIPTION
Adds support for Tracker v5 API and JSON response type. Left in the legacy support for v3 and xml API