### PR TITLE
Comments out lines in ruby after a markdown hr

### DIFF
--- a/lib/pickler/tracker/story.rb
+++ b/lib/pickler/tracker/story.rb
@@ -7,7 +7,7 @@ class Pickler
 
       attr_reader :project, :labels
       reader :url
-      date_reader :created_at, :accepted_at, :deadline
+      date_reader :created_at, :updated_at, :accepted_at, :deadline
       accessor :current_state, :name, :description, :owned_by, :requested_by, :story_type
 
       def initialize(project, attributes = {})
@@ -80,7 +80,7 @@ class Pickler
       end
 
       def to_s(format = :tag)
-        to_s = "#{header(format)}\n#{story_type.capitalize}: #{name}\n"
+        to_s = "#{header(format)}\n#{updated_at_annotation}\n#{story_type.capitalize}: #{name}\n"
         if description_lines.index('---')
           description_array = description_lines.each_slice(description_lines.index('---')).to_a
           top_description_lines = description_array.first # feature story
@@ -111,6 +111,10 @@ class Pickler
         else
           "# #{url}"
         end
+      end
+
+      def updated_at_annotation
+        "# updated_at: #{updated_at}"
       end
 
       def to_s=(body)


### PR DESCRIPTION
hr being a horizontal rule. Specifically a three dash horizontal rule.

Looks for `---` and slices the array on that to "top half" and "bottom half".
For the bottom half, either add comments or remove them when pulling or pushing
respectively.

I know this isn't the most elegant thing, but it's working for now. I'm going to test it a bit and might clean things up a bit. Mostly pushing to reference the gem from my branch, but wanted to see if anyone else is interested in this so throwing up this PR.

Some examples of why I needed this (please forgive the user stories themselves, we're working on bringing that process into our workflow across the broader team at the moment and have some things to tighten up on that front).

The MD preview version 

![image](https://user-images.githubusercontent.com/4521/28807836-5e501040-763d-11e7-8f89-d2fa6c347ddc.png)

Editing retains the indentation

![image](https://user-images.githubusercontent.com/4521/28807846-77a03084-763d-11e7-9f11-bc0114b8effa.png)